### PR TITLE
Add empty config for TLS

### DIFF
--- a/server/flex-gateway/templates/redis-config-template.yaml
+++ b/server/flex-gateway/templates/redis-config-template.yaml
@@ -8,4 +8,4 @@ spec:
     redis:
       address: $REDIS_ADDRESS:6379
       password: $REDIS_PW
-
+      tls: {}


### PR DESCRIPTION
Add empty config for TLS, since leaving it actually empty made it ignore TLS entirely which we don't want.